### PR TITLE
Daily reports class

### DIFF
--- a/app/integrators/covid_api_v2_integrator.py
+++ b/app/integrators/covid_api_v2_integrator.py
@@ -37,7 +37,7 @@ class CovidAPIv2Integrator:
         }
     """
     def __init__(self, daily_reports: DailyReports) -> None:
-        """ Initiate DataFrames """
+        """ Initiate instances """
         self.lookup_table = get_data_lookup_table()
         self.scheme = {
             'data': None,

--- a/app/integrators/covid_api_v2_integrator.py
+++ b/app/integrators/covid_api_v2_integrator.py
@@ -24,8 +24,7 @@ from models.covid_api_v2_model import (ActiveModel, ConfirmedModel,
                                          TimeseriesUSDataModel,
                                          TimeseriesUSInfoModel,
                                          TimeseriesUSModel, TotalModel)
-from utils.get_data import (get_data_daily_reports,
-                              get_data_daily_reports_us, get_data_lookup_table,
+from utils.get_data import (DailyReports, get_data_lookup_table,
                               get_data_time_series, get_US_time_series)
 
 
@@ -37,7 +36,7 @@ class CovidAPIv2Integrator:
             "ts": int = "{timestamp}
         }
     """
-    def __init__(self) -> None:
+    def __init__(self, daily_reports: DailyReports) -> None:
         """ Initiate DataFrames """
         self.lookup_table = get_data_lookup_table()
         self.scheme = {
@@ -45,6 +44,7 @@ class CovidAPIv2Integrator:
             'dt': None,
             'ts': None
         }
+        self.daily_reports=daily_reports
     
     def wrap_data(func) -> ResponseModel:
         """ Wrap a result in a schemed data """
@@ -71,7 +71,7 @@ class CovidAPIv2Integrator:
     def get_current(self) -> List[CurrentModel]:
         """ Current data from all locations (Lastest date) """
         concerned_columns = ['Confirmed', 'Deaths', 'Recovered', 'Active']
-        self.df = get_data_daily_reports() # Get base data
+        self.df = self.daily_reports.get_data_daily_reports() # Get base data
         self.df_grp_by_country = self.df.groupby('Country_Region')[concerned_columns].sum()
         self.df_grp_by_country[concerned_columns] = self.df_grp_by_country[concerned_columns].astype(int)
 
@@ -89,7 +89,7 @@ class CovidAPIv2Integrator:
     @wrap_data
     def get_current_US(self) -> List[CurrentUSModel]:
         """ Get current data for USA's situation """
-        self.df_US = get_data_daily_reports_us() # Get base data
+        self.df_US = self.daily_reports.get_data_daily_reports(US=True) # Get base data
 
         concerned_columns = ['Confirmed', 'Deaths', 'Recovered', 'Active']
         df = self.df_US.groupby(['Province_State'])[concerned_columns].sum().sort_values(by='Confirmed', ascending=False)
@@ -128,7 +128,7 @@ class CovidAPIv2Integrator:
     @wrap_data
     def get_confirmed(self) -> ConfirmedModel:
         """ Summation of all confirmed cases """
-        self.df = get_data_daily_reports() # Get base data
+        self.df = self.daily_reports.get_data_daily_reports() # Get base data
         data = ConfirmedModel(
             confirmed=int(self.df['Confirmed'].sum())
         )
@@ -140,7 +140,7 @@ class CovidAPIv2Integrator:
     @wrap_data
     def get_deaths(self) -> DeathsModel:
         """ Summation of all deaths """
-        self.df = get_data_daily_reports() # Get base data
+        self.df = self.daily_reports.get_data_daily_reports() # Get base data
         data = DeathsModel(
             deaths=int(self.df['Deaths'].sum())
         )
@@ -152,7 +152,7 @@ class CovidAPIv2Integrator:
     @wrap_data
     def get_recovered(self) -> RecoveredModel:
         """ Summation of all recovers """
-        self.df = get_data_daily_reports() # Get base data
+        self.df = self.daily_reports.get_data_daily_reports() # Get base data
         data = RecoveredModel(
             recovered=int(self.df['Recovered'].sum())
         )
@@ -164,7 +164,7 @@ class CovidAPIv2Integrator:
     @wrap_data
     def get_active(self) -> ActiveModel:
         """ Summation of all actives """
-        self.df = get_data_daily_reports() # Get base data
+        self.df = self.daily_reports.get_data_daily_reports() # Get base data
         data = ActiveModel(
             active=int(self.df['Active'].sum())
         )
@@ -176,7 +176,7 @@ class CovidAPIv2Integrator:
     @wrap_data
     def get_total(self) -> TotalModel:
         """ Summation of Confirmed, Deaths, Recovered, Active """
-        self.df = get_data_daily_reports() # Get base data
+        self.df = self.daily_reports.get_data_daily_reports() # Get base data
         data = TotalModel(
             confirmed=int(self.df['Confirmed'].sum()),
             deaths=int(self.df['Deaths'].sum()),

--- a/app/routers/v2/router_api_v2.py
+++ b/app/routers/v2/router_api_v2.py
@@ -14,9 +14,11 @@ from integrators.covid_api_v2_integrator import CovidAPIv2Integrator
 from starlette.requests import Request
 
 from . import v2
+from utils.get_data import DailyReports
 
 # Initiate Integrator
-COVID_API_V2 = CovidAPIv2Integrator()
+DAILY_REPORTS = DailyReports()
+COVID_API_V2 = CovidAPIv2Integrator(DAILY_REPORTS)
 
 
 # Logging

--- a/app/tests/test_get_data.py
+++ b/app/tests/test_get_data.py
@@ -6,46 +6,46 @@ DATE: 11-April-2020
 """
 # Import libraries
 import pandas as pd
-from ..utils import get_data
+from ..utils.get_data import DailyReports, get_data_lookup_table, get_data_time_series, get_US_time_series
 
 
 # Test - Get Lookup table
 def test_get_data_lookup_table() -> None:
-    result = get_data.get_data_lookup_table()
+    result = get_data_lookup_table()
     assert len(result) > 0
     assert isinstance(result, dict) is True
 
 
 # Test - Get data from daily reports
 def test_get_data_daily_reports() -> None:
-    result = get_data.get_data_daily_reports()
+    result = DailyReports.get_data_daily_reports()
     assert len(result) > 0
     assert isinstance(result, pd.DataFrame) is True 
 
 
 # Test - Get data from time series
 def test_get_data_time_series() -> None:
-    result = get_data.get_data_time_series()
+    result = get_data_time_series()
     assert len(result) > 0
     assert isinstance(result, dict) is True
 
 
 # Test - Get data from time series (US)
 def test_get_US_time_series() -> None:
-    result = get_data.get_US_time_series()
+    result = get_US_time_series()
     assert len(result) > 0
     assert isinstance(result, dict) is True
 
 
 # Test - Get Data (API v1)
 def test_get_data() -> None:
-    result = get_data.get_data()
+    result = get_data()
     assert len(result) > 0
     assert isinstance(result, dict) is True
 
 
 # Test - Get Data (API v1)
 def test_get_data(time_series = True) -> None:
-    result = get_data.get_data()
+    result = get_data()
     assert len(result) > 0
     assert isinstance(result, dict) is True

--- a/app/tests/test_get_data.py
+++ b/app/tests/test_get_data.py
@@ -6,8 +6,9 @@ DATE: 11-April-2020
 """
 # Import libraries
 import pandas as pd
-from ..utils.get_data import DailyReports, get_data_lookup_table, get_data_time_series, get_US_time_series
+from ..utils.get_data import DailyReports, get_data_lookup_table, get_data_time_series, get_US_time_series, get_data
 
+daily_reports = DailyReports()
 
 # Test - Get Lookup table
 def test_get_data_lookup_table() -> None:
@@ -18,7 +19,7 @@ def test_get_data_lookup_table() -> None:
 
 # Test - Get data from daily reports
 def test_get_data_daily_reports() -> None:
-    result = DailyReports.get_data_daily_reports()
+    result = daily_reports.get_data_daily_reports()
     assert len(result) > 0
     assert isinstance(result, pd.DataFrame) is True 
 

--- a/app/utils/get_data.py
+++ b/app/utils/get_data.py
@@ -27,38 +27,23 @@ def get_data_lookup_table() -> Dict[str, str]:
 
     return data
 
+class DailyReports:
+    def __init__(self) -> None: 
+        self.latest_base_url = helper_get_latest_data_url(JHU_CSSE_FILE_PATHS['BASE_URL_DAILY_REPORTS'])
 
-# Get data from daily reports
-def get_data_daily_reports() -> pd.DataFrame:
-    """ Get data from BASE_URL_DAILY_REPORTS """
-    # Check the latest file
-    latest_base_url = helper_get_latest_data_url(JHU_CSSE_FILE_PATHS['BASE_URL_DAILY_REPORTS'])
-
-    # Extract the data
-    df = pd.read_csv(latest_base_url)
-
-    # Data pre-processing
-    concerned_columns = ['Confirmed', 'Deaths', 'Recovered', 'Active']
-    df = helper_df_cols_cleaning(df, concerned_columns, int)
-    
-    return df
-
-
-# Get data from daily reports (USA)
-def get_data_daily_reports_us() -> pd.DataFrame:
-    """ Get data from BASE_URL_DAILY_REPORTS """
-    # Check the latest file
-    latest_base_url = helper_get_latest_data_url(JHU_CSSE_FILE_PATHS['BASE_URL_DAILY_REPORTS_US'])
-
-    # Extract the data
-    df = pd.read_csv(latest_base_url)
-
-    # Data pre-processing
-    concerned_columns = ['Confirmed', 'Deaths', 'Recovered', 'Active']
-    df = helper_df_cols_cleaning(df, concerned_columns, int)
-    
-    return df
-
+    # Get data from daily reports
+    def get_data_daily_reports(self, US=False) -> pd.DataFrame:
+        """ Get data from BASE_URL_DAILY_REPORTS """
+        # Extract the data
+        if US is False:
+            df = pd.read_csv(self.latest_base_url)
+        else: 
+             df = pd.read_csv(JHU_CSSE_FILE_PATHS['BASE_URL_DAILY_REPORTS_US'])
+        # Data pre-processing
+        concerned_columns = ['Confirmed', 'Deaths', 'Recovered', 'Active']
+        df = helper_df_cols_cleaning(df, concerned_columns, int)
+        
+        return df
 
 # Get data from time series
 def get_data_time_series() -> Dict[str, pd.DataFrame]:

--- a/app/utils/get_data.py
+++ b/app/utils/get_data.py
@@ -32,13 +32,17 @@ class DailyReports:
         self.latest_base_url = helper_get_latest_data_url(JHU_CSSE_FILE_PATHS['BASE_URL_DAILY_REPORTS'])
 
     # Get data from daily reports
-    def get_data_daily_reports(self, US=False) -> pd.DataFrame:
+    def get_data_daily_reports(self, US: bool = False) -> pd.DataFrame:
         """ Get data from BASE_URL_DAILY_REPORTS """
         # Extract the data
-        if US is False:
-            df = pd.read_csv(self.latest_base_url)
-        else: 
-             df = pd.read_csv(JHU_CSSE_FILE_PATHS['BASE_URL_DAILY_REPORTS_US'])
+        latest_base_url = None
+        if US:
+            latest_base_url = helper_get_latest_data_url(JHU_CSSE_FILE_PATHS['BASE_URL_DAILY_REPORTS_US'])
+        else:
+            latest_base_url = helper_get_latest_data_url(JHU_CSSE_FILE_PATHS['BASE_URL_DAILY_REPORTS'])
+        
+        # Extract the data
+        df = pd.read_csv(latest_base_url)
         # Data pre-processing
         concerned_columns = ['Confirmed', 'Deaths', 'Recovered', 'Active']
         df = helper_df_cols_cleaning(df, concerned_columns, int)


### PR DESCRIPTION
### Related Issue:

None

### Proposed Changes

Adding a class named `DailyReports` to wrap the utility functions defined in `get_data.py`. The `CovidAPIv2Integrator` would have a `has_a` relationship with `DailyReports` and have it passed into its initializer so that it can be used to get the overall daily reports for all countries or specifically for the US by sending the `US=True` flag when calling the `get_data_daily_reports` method. In addition, this could further be refactored in the future to instead pass in the name of the country as an argument if we wish to add this functionality to the Covid19 API.  

### Checklist

* [x] Tests
* [ ] Translations
* [ ] Documentation
